### PR TITLE
WIP : added fastapi & uvicorn to the web interface

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ pytest>=7.4.0
 pandas>=2.0.3
 openpyxl>=3.1.2
 fastapi>=0.100.1
+uvicorn>=0.23.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ pytest>=7.4.0
 # Conversion and data preparation
 pandas>=2.0.3
 openpyxl>=3.1.2
+fastapi>=0.100.1

--- a/web/main.py
+++ b/web/main.py
@@ -15,7 +15,7 @@ app.add_middleware(
 )
 
 @app.get('/',include_in_schema=False)
-def home():
+def homepage():
     return  get_swagger_ui_html(openapi_url=app.openapi_url,title=app.title + " - Swagger UI",)
 @app.get("/ajaxGet")
 def getAjax(text: str, action: str,order:int=0,lastmark:int=0):

--- a/web/main.py
+++ b/web/main.py
@@ -26,6 +26,7 @@ def getAjax(text: str, action: str,order:int=0,lastmark:int=0):
     and actions as endpoint or payload type
     for now, im settling with the current structure, but there is room to improve.
 
+
     '''
     resulttext = adaat.DoAction(text, action,{"order":order,"lastmark":lastmark})
     results = {'result':resulttext, 'order':0}

--- a/web/main.py
+++ b/web/main.py
@@ -1,0 +1,32 @@
+from fastapi import FastAPI
+from pydantic import BaseModel
+from fastapi.middleware.cors import CORSMiddleware
+from fastapi.openapi.docs import get_swagger_ui_html
+import adaat
+import json
+app = FastAPI()
+# we allow all origings, using wildcard, when frontend interface origins are known, remove wildcard.
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+@app.get('/',include_in_schema=False)
+def home():
+    return  get_swagger_ui_html(openapi_url=app.openapi_url,title=app.title + " - Swagger UI",)
+@app.get("/ajaxGet")
+def getAjax(text: str, action: str,order:int=0,lastmark:int=0):
+    '''
+    TODO: we need typechecking here (for all params, and for the set of actions), we can use pydantic, and BaseModel to achive that
+    we have actions,text,option. a better structure would use options as query params
+    and text as payload
+    and actions as endpoint or payload type
+    for now, im settling with the current structure, but there is room to improve.
+
+    '''
+    resulttext = adaat.DoAction(text, action,{"order":order,"lastmark":lastmark})
+    results = {'result':resulttext, 'order':0}
+    return  results

--- a/web/main.py
+++ b/web/main.py
@@ -5,7 +5,7 @@ from fastapi.openapi.docs import get_swagger_ui_html
 import adaat
 import json
 app = FastAPI()
-# we allow all origings, using wildcard, when frontend interface origins are known, remove wildcard.
+# we allow all origins, using wildcard, when frontend interface origins are known, remove wildcard.
 app.add_middleware(
     CORSMiddleware,
     allow_origins=["*"],


### PR DESCRIPTION
NOTE : this pr is WIP

there is a lot to cover here, ill be working on diagrams describing my suggestion for how the web interface should be structured. furthermore, I think we should lose coupling, and differentiate between the interface and the actual logic. so that the functionality can be accessed by a cli or web. 

How to test this PR ? 

1- install new requirement
2- go to web directory and run 
`uvicorn main:app --reload --port 5000`
3- go to the frontend, test the endpoints there.
